### PR TITLE
Fix PlanStep initialisers after args field

### DIFF
--- a/src/plan.rs
+++ b/src/plan.rs
@@ -28,9 +28,11 @@ impl WorkflowPlan {
             self.plan = vec![
                 PlanStep {
                     cmd: "sort".to_string(),
+                    args: Vec::new(),
                 },
                 PlanStep {
                     cmd: "uniq".to_string(),
+                    args: Vec::new(),
                 },
             ];
         }
@@ -76,7 +78,10 @@ fn parse_any_form(text: &str) -> Result<WorkflowPlan, serde_json::Error> {
             plan: simple
                 .plan
                 .into_iter()
-                .map(|cmd| PlanStep { cmd })
+                .map(|cmd| PlanStep {
+                    cmd,
+                    args: Vec::new(),
+                })
                 .collect(),
         });
     }
@@ -89,7 +94,10 @@ fn parse_any_form(text: &str) -> Result<WorkflowPlan, serde_json::Error> {
         return Ok(WorkflowPlan {
             plan: cmds
                 .into_iter()
-                .map(|cmd| PlanStep { cmd })
+                .map(|cmd| PlanStep {
+                    cmd,
+                    args: Vec::new(),
+                })
                 .collect(),
         });
     }


### PR DESCRIPTION
Add missing args initialisation in plan normalisation and fallback parsing paths so that PlanStep remains constructible after adding the args field. This fixes cargo install and source builds that were failing with E0063.