### PR TITLE
Add embedded llm backend (feature-gated)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,14 @@ name = "agx"
 version = "0.1.0"
 edition = "2021"
 
+[features]
+embedded-backend = ["llm", "rand"]
+
 [dependencies]
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+llm = { version = "0.1", default-features = false, features = ["models"], optional = true }
+rand = { version = "0.8", optional = true }
 
+[profile.dev.package.ggml-sys]
+opt-level = 3


### PR DESCRIPTION
This PR adds a feature-gated embedded model backend using the  crate, so AGX can run the planner fully locally without Ollama when desired.

Key points:
- Introduce a new Cargo feature  which pulls in:
  - 
  -  for sampling.
- Extend  with an  variant, selected via  or  when the feature is enabled. Without the feature, these values fall back to the existing Ollama backend.
- Extend  so that for the embedded backend,  comes from  (default: ).
- Implement  (behind ) using  and a local GGML model file:
  - Architecture is read from  and parsed as , defaulting to .
  - Uses  and .
  - Runs inference via  / , collecting tokens into a  returned as the planner JSON.
- Wire  to construct either  or  depending on .

By default (no features, no env changes), behaviour remains exactly as before: AGX still calls  for planning. When built with  and configured with  and , the planner will instead run entirely in-process using the  crate.