### PR TITLE
Repair planner JSON parsing for awk-style quotes

### DIFF
--- a/src/plan.rs
+++ b/src/plan.rs
@@ -69,12 +69,39 @@ fn strip_markdown_fence(value: &str) -> String {
 }
 
 fn parse_any_form(text: &str) -> Result<WorkflowPlan, serde_json::Error> {
-    if let Ok(plan) = serde_json::from_str::<WorkflowPlan>(text) {
+    if let Some(plan) = try_all_known_forms(text) {
         return Ok(plan);
     }
 
+    if let Some(extracted) = extract_first_json_value(text) {
+        if let Some(plan) = try_all_known_forms(extracted) {
+            return Ok(plan);
+        }
+    }
+
+    let repaired = repair_unescaped_quotes(text);
+    if repaired != text {
+        if let Some(plan) = try_all_known_forms(&repaired) {
+            return Ok(plan);
+        }
+
+        if let Some(extracted) = extract_first_json_value(&repaired) {
+            if let Some(plan) = try_all_known_forms(extracted) {
+                return Ok(plan);
+            }
+        }
+    }
+
+    serde_json::from_str::<WorkflowPlan>(text)
+}
+
+fn try_all_known_forms(text: &str) -> Option<WorkflowPlan> {
+    if let Ok(plan) = serde_json::from_str::<WorkflowPlan>(text) {
+        return Some(plan);
+    }
+
     if let Ok(simple) = serde_json::from_str::<SimpleWorkflowPlan>(text) {
-        return Ok(WorkflowPlan {
+        return Some(WorkflowPlan {
             plan: simple
                 .plan
                 .into_iter()
@@ -87,11 +114,11 @@ fn parse_any_form(text: &str) -> Result<WorkflowPlan, serde_json::Error> {
     }
 
     if let Ok(steps) = serde_json::from_str::<Vec<PlanStep>>(text) {
-        return Ok(WorkflowPlan { plan: steps });
+        return Some(WorkflowPlan { plan: steps });
     }
 
     if let Ok(cmds) = serde_json::from_str::<Vec<String>>(text) {
-        return Ok(WorkflowPlan {
+        return Some(WorkflowPlan {
             plan: cmds
                 .into_iter()
                 .map(|cmd| PlanStep {
@@ -102,13 +129,7 @@ fn parse_any_form(text: &str) -> Result<WorkflowPlan, serde_json::Error> {
         });
     }
 
-    if let Some(extracted) = extract_first_json_value(text) {
-        if extracted != text {
-            return parse_any_form(extracted);
-        }
-    }
-
-    serde_json::from_str::<WorkflowPlan>(text)
+    None
 }
 
 fn extract_first_json_value(text: &str) -> Option<&str> {
@@ -141,4 +162,102 @@ fn extract_first_json_value(text: &str) -> Option<&str> {
     }
 
     None
+}
+
+fn repair_unescaped_quotes(value: &str) -> String {
+    let mut output = String::with_capacity(value.len());
+    let mut chars = value.chars().peekable();
+    let mut in_string = false;
+    let mut escaped = false;
+
+    while let Some(ch) = chars.next() {
+        if ch == '"' {
+            if !in_string {
+                in_string = true;
+                output.push(ch);
+                continue;
+            }
+
+            if escaped {
+                output.push(ch);
+                escaped = false;
+                continue;
+            }
+
+            let mut lookahead = chars.clone();
+            let mut next_non_ws = None;
+
+            while let Some(next) = lookahead.next() {
+                if !next.is_whitespace() {
+                    next_non_ws = Some(next);
+                    break;
+                }
+            }
+
+            let should_escape = match next_non_ws {
+                Some(',') | Some(']') | Some('}') | Some(':') | None => false,
+                _ => true,
+            };
+
+            if should_escape {
+                output.push('\\');
+                output.push('"');
+                continue;
+            } else {
+                in_string = false;
+                output.push('"');
+                continue;
+            }
+        }
+
+        if ch == '\\' {
+            if in_string && !escaped {
+                escaped = true;
+            } else {
+                escaped = false;
+            }
+        } else {
+            escaped = false;
+        }
+
+        output.push(ch);
+
+        if !in_string {
+            escaped = false;
+        }
+    }
+
+    output
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn repairs_unescaped_quotes_in_args() {
+        let broken = r#"{
+            "plan": [
+                {"cmd": "sort"},
+                {"cmd": "awk", "args": ["-F"/"/,NR==1;print length($NF)"]}
+            ]
+        }"#;
+
+        let plan = WorkflowPlan::from_str(broken).expect("plan should be repaired");
+
+        assert_eq!(plan.plan.len(), 2);
+        assert_eq!(plan.plan[1].cmd, "awk");
+        assert_eq!(
+            plan.plan[1].args,
+            vec!["-F\"/\",NR==1;print length($NF)".to_string()]
+        );
+    }
+
+    #[test]
+    fn leaves_valid_json_unchanged() {
+        let valid = r#"{"plan":[{"cmd":"cat","args":["file.txt"]}]}"#;
+        let repaired = repair_unescaped_quotes(valid);
+
+        assert_eq!(valid, repaired);
+    }
 }


### PR DESCRIPTION
## Summary
- add a repair pass to the plan parser so that it can handle planner output that forgets to escape double quotes inside arguments
- keep the existing JSON shapes while reusing a helper that attempts each supported structure before and after the repair step
- add regression tests to ensure we repair the broken output and leave valid JSON untouched

## Testing
- cargo fmt
- cargo test *(fails: unable to download crates/index because outbound network access is blocked in the execution environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69177448ce7c8320a096e32a150a816c)