### PR TITLE
Add CLI flags for help, version, and debug

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,19 +1,91 @@
+const DISPLAY_VERSION: &str = "0.1";
+
+const HELP_TEXT: &str = "\
+AGX - AI command execution helper\n\
+\n\
+Usage:\n\
+    agx [OPTIONS] <instruction>\n\
+\n\
+Options:\n\
+    -h, --help        Print this help text.\n\
+    -v, --version     Show the version and this help output.\n\
+    -d, --debug       Enable verbose logging to stderr.\n\
+\n\
+Environment variables:\n\
+    AGX_BACKEND       Selects the planner backend (ollama or embedded).\n\
+    AGX_OLLAMA_MODEL  Ollama model to run when using the Ollama backend (default: phi3:mini).\n\
+    AGX_MODEL_PATH    Filesystem path to a local model when using the embedded backend.\n\
+    AGX_MODEL_ARCH    Architecture for embedded models (for example: llama).\n\
+";
+
 pub struct CliConfig {
-    pub instruction: String,
+    pub instruction: Option<String>,
+    pub show_help: bool,
+    pub show_version: bool,
+    pub debug: bool,
 }
 
 impl CliConfig {
     pub fn from_env() -> Result<Self, String> {
+        let mut instruction: Option<String> = None;
+        let mut show_help = false;
+        let mut show_version = false;
+        let mut debug = false;
+
         let mut arguments = std::env::args().skip(1);
 
-        let instruction = match arguments.next() {
-            Some(value) => value,
-            None => {
-                return Err("Usage: agx <instruction>".to_string());
-            }
-        };
+        while let Some(argument) = arguments.next() {
+            match argument.as_str() {
+                "--help" | "-h" => {
+                    show_help = true;
+                }
+                "--version" | "-v" => {
+                    show_version = true;
+                    show_help = true;
+                }
+                "--debug" | "-d" => {
+                    debug = true;
+                }
+                "--" => {
+                    let rest: Vec<String> = arguments.collect();
 
-        Ok(Self { instruction })
+                    if !rest.is_empty() {
+                        instruction = Some(rest.join(" "));
+                    }
+
+                    break;
+                }
+                _ if argument.starts_with('-') => {
+                    return Err(format!(
+                        "unknown option: {argument}\n\nRun `agx --help` or `agx -v` for more information."
+                    ));
+                }
+                _ => {
+                    if instruction.is_none() {
+                        instruction = Some(argument);
+                    } else {
+                        return Err(
+                            "multiple instructions provided. Quote the instruction if it contains spaces."
+                                .to_string(),
+                        );
+                    }
+                }
+            }
+        }
+
+        Ok(Self {
+            instruction,
+            show_help,
+            show_version,
+            debug,
+        })
     }
 }
 
+pub fn print_help() {
+    println!("{HELP_TEXT}");
+}
+
+pub fn print_version() {
+    println!("agx {DISPLAY_VERSION}");
+}

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -1,4 +1,13 @@
-pub fn info(message: &str) {
-    eprintln!("[agx] {message}");
+use std::sync::atomic::{AtomicBool, Ordering};
+
+static DEBUG_ENABLED: AtomicBool = AtomicBool::new(false);
+
+pub fn set_debug(enabled: bool) {
+    DEBUG_ENABLED.store(enabled, Ordering::Relaxed);
 }
 
+pub fn info(message: &str) {
+    if DEBUG_ENABLED.load(Ordering::Relaxed) {
+        eprintln!("[agx] {message}");
+    }
+}


### PR DESCRIPTION
## Summary
- add a richer CLI parser that supports --help/-h, --version/-v, and --debug/-d, and expose the requested help text with environment variable descriptions
- gate logging output behind the new debug flag so normal runs stay quiet unless --debug is passed
- allow the main entrypoint to print help/version information and exit before invoking the planner when those flags are used

## Testing
- `cargo fmt`
- `cargo test` *(fails: unable to download crates due to CONNECT tunnel 403)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6917862223a883208925d2f884f7e9d4)