### PR TITLE
AGX-032: Add Ops mode commands

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,6 +12,10 @@ Transform natural-language user instructions into deterministic JSON workflow pl
 - `PLAN add "<instruction>"` – capture the instruction, run the configured planner backend, and append steps
 - `PLAN preview` – pretty-print / lint the in-progress plan
 - `PLAN submit` – send the finalized plan to AGQ via RESP with session-key auth and emit machine-readable status
+- Ops commands:
+  - `JOBS list [--json]`
+  - `WORKERS list [--json]`
+  - `QUEUE stats [--json]`
 
 ### Input Context
 - Natural-language instructions

--- a/README.md
+++ b/README.md
@@ -56,6 +56,16 @@ Phase 1 introduces a `PLAN` REPL-style workflow:
 
 On success, the CLI prints JSON including the `job_id` and writes metadata alongside the plan buffer for future Ops commands.
 
+## Ops mode
+
+Use Ops commands to inspect AGQ without leaving the CLI:
+
+- `JOBS list [--json]`
+- `WORKERS list [--json]`
+- `QUEUE stats [--json]`
+
+These reuse the same AGQ configuration as PLAN submit. Add `--json` for machine-readable output; otherwise, a simple list is printed.
+
 ## Examples
 
 ```bash

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -37,6 +37,10 @@ Deliverables:
   - `PLAN add "<instruction>"`  
   - `PLAN preview`  
   - `PLAN submit`  
+  - Ops Mode:
+    - `JOBS list`
+    - `WORKERS list`
+    - `QUEUE stats`
 - LLM integration for plan shaping  
 - JSON plan schema  
 - Ops-mode scaffolding:


### PR DESCRIPTION
## Summary
- Adds Ops commands (, , ) to the CLI with  output support.
- Reuses the AGQ RESP client for Ops queries and shares env-based config (AGQ_ADDR, AGQ_SESSION_KEY, AGQ_TIMEOUT_SECS).
- Updates help text, README, AGENTS, and ROADMAP to describe Ops mode.

## Testing
- cargo test
