### PR TITLE
feat: REPL command shortcuts and improved help (AGX-057)

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,16 +47,20 @@ The REPL provides:
 
 ### REPL Commands
 
-- `add "<instruction>"` — Generate and append plan steps using Echo model
-- `preview` — Show current plan
-- `edit <num>` — Modify a specific step
-- `remove <num>` — Delete a specific step
-- `clear` — Reset the plan
-- `validate` — Run Delta model validation (coming in AGX-045/046)
-- `submit` — Submit plan to AGQ (use `agx PLAN submit` for now)
+All commands support single-letter shortcuts shown in brackets:
+
+- `[a]dd "<instruction>"` — Generate and append plan steps using Echo model
+- `[p]review` — Show current plan
+- `[e]dit <num>` — Modify a specific step
+- `[r]emove <num>` — Delete a specific step
+- `[c]lear` — Reset the plan
+- `[v]alidate` — Run Delta model validation (coming in AGX-045/046)
+- `[s]ubmit` — Submit plan to AGQ (use `agx PLAN submit` for now)
 - `save` — Manually save session
-- `help` — Show available commands
-- `quit` — Exit REPL
+- `[h]elp` — Show available commands
+- `[q]uit` — Exit REPL
+
+**Tip**: Type either the full command or just the first letter (e.g., `a` or `add`)
 
 ### Keyboard Shortcuts
 
@@ -114,30 +118,38 @@ PLAN submit now wraps the full plan into a job envelope so all steps run on a si
 # Enter interactive mode
 agx
 
-# In the REPL:
-agx (0)> add "convert PDF to text"
+# In the REPL (using shortcuts):
+agx (0)> a "convert PDF to text"
 🤖 Generating plan steps...
 ✓ Added 2 task(s)
 
-agx (2)> preview
+agx (2)> p
 📋 Current plan (2 tasks):
 
   1. pdf-to-text input.pdf
   2. save-output output.txt
 
-agx (2)> edit 2
+agx (2)> e 2
 Editing task 2:
   Current: save-output output.txt
 
   New command> write-file output.txt
 ✓ Updated task 2
 
-agx (2)> submit
+agx (2)> h
+AGX Interactive REPL v0.1.0
+
+Commands:
+  [a]dd <instruction>    Generate and append plan steps
+  [p]review              Show current plan
+  ...
+
+agx (2)> s
 📤 Submitting plan to AGQ...
 ⚠️  Submit via REPL not yet fully integrated
    Use 'agx PLAN submit' for now
 
-agx (2)> quit
+agx (2)> q
 Saving session...
 Goodbye!
 ```

--- a/src/repl.rs
+++ b/src/repl.rs
@@ -134,7 +134,7 @@ impl ReplCommand {
         let cmd = parts[0].to_lowercase();
 
         match cmd.as_str() {
-            "add" => {
+            "add" | "a" => {
                 let instruction = parts.get(1)
                     .ok_or_else(|| "add requires an instruction".to_string())?
                     .trim();
@@ -145,8 +145,8 @@ impl ReplCommand {
 
                 Ok(ReplCommand::Add(instruction.to_string()))
             }
-            "preview" | "show" | "list" => Ok(ReplCommand::Preview),
-            "edit" => {
+            "preview" | "show" | "list" | "p" => Ok(ReplCommand::Preview),
+            "edit" | "e" => {
                 let num_str = parts.get(1)
                     .ok_or_else(|| "edit requires a step number".to_string())?
                     .trim();
@@ -160,7 +160,7 @@ impl ReplCommand {
 
                 Ok(ReplCommand::Edit(num))
             }
-            "remove" | "delete" | "rm" => {
+            "remove" | "delete" | "rm" | "r" => {
                 let num_str = parts.get(1)
                     .ok_or_else(|| "remove requires a step number".to_string())?
                     .trim();
@@ -174,11 +174,11 @@ impl ReplCommand {
 
                 Ok(ReplCommand::Remove(num))
             }
-            "clear" | "reset" | "new" => Ok(ReplCommand::Clear),
-            "validate" => Ok(ReplCommand::Validate),
-            "submit" => Ok(ReplCommand::Submit),
+            "clear" | "reset" | "new" | "c" => Ok(ReplCommand::Clear),
+            "validate" | "v" => Ok(ReplCommand::Validate),
+            "submit" | "s" => Ok(ReplCommand::Submit),
             "save" => Ok(ReplCommand::Save),
-            "help" | "?" => Ok(ReplCommand::Help),
+            "help" | "?" | "h" => Ok(ReplCommand::Help),
             "quit" | "exit" | "q" => Ok(ReplCommand::Quit),
             _ => Err(format!("unknown command: {}. Type 'help' for available commands", cmd)),
         }
@@ -526,23 +526,30 @@ impl Repl {
 
     /// Show help text
     fn cmd_help(&self) {
-        println!("AGX REPL Commands:");
+        println!("AGX Interactive REPL v{}", env!("CARGO_PKG_VERSION"));
         println!();
-        println!("  add <instruction>     Generate and append plan steps");
-        println!("  preview               Show current plan");
-        println!("  edit <num>            Modify a specific step");
-        println!("  remove <num>          Delete a specific step");
-        println!("  clear                 Reset the plan");
-        println!("  validate              Run Delta model validation");
-        println!("  submit                Submit plan to AGQ");
-        println!("  save                  Manually save session");
-        println!("  help                  Show this help");
-        println!("  quit                  Exit REPL");
+        println!("Commands:");
+        println!("  [a]dd <instruction>    Generate and append plan steps");
+        println!("  [p]review              Show current plan");
+        println!("  [e]dit <num>           Modify a specific step");
+        println!("  [r]emove <num>         Delete a specific step");
+        println!("  [c]lear                Reset the plan");
         println!();
-        println!("Keyboard shortcuts:");
-        println!("  Ctrl-G                Enter vi mode for editing");
-        println!("  Ctrl-C                Cancel current input");
-        println!("  Ctrl-D                Exit REPL");
+        println!("Plan Actions:");
+        println!("  [v]alidate             Run Delta model validation");
+        println!("  [s]ubmit               Submit plan to AGQ");
+        println!("  save                   Manually save session");
+        println!();
+        println!("Session:");
+        println!("  [h]elp                 Show this help");
+        println!("  [q]uit                 Exit REPL");
+        println!();
+        println!("Keyboard Shortcuts:");
+        println!("  Ctrl-G                 Enter vi mode for editing");
+        println!("  Ctrl-C                 Cancel current input");
+        println!("  Ctrl-D                 Exit REPL");
+        println!();
+        println!("Tip: Type the full command or just the first letter (e.g., 'a' or 'add')");
         println!();
     }
 
@@ -656,6 +663,55 @@ mod tests {
     fn parse_empty_command() {
         let result = ReplCommand::parse("");
         assert!(result.is_err());
+    }
+
+    // Shortcut tests (AGX-057)
+    #[test]
+    fn parse_add_shortcut() {
+        let cmd = ReplCommand::parse("a sort numbers").unwrap();
+        assert_eq!(cmd, ReplCommand::Add("sort numbers".to_string()));
+    }
+
+    #[test]
+    fn parse_preview_shortcut() {
+        assert_eq!(ReplCommand::parse("p").unwrap(), ReplCommand::Preview);
+    }
+
+    #[test]
+    fn parse_edit_shortcut() {
+        let cmd = ReplCommand::parse("e 2").unwrap();
+        assert_eq!(cmd, ReplCommand::Edit(2));
+    }
+
+    #[test]
+    fn parse_remove_shortcut() {
+        let cmd = ReplCommand::parse("r 1").unwrap();
+        assert_eq!(cmd, ReplCommand::Remove(1));
+    }
+
+    #[test]
+    fn parse_clear_shortcut() {
+        assert_eq!(ReplCommand::parse("c").unwrap(), ReplCommand::Clear);
+    }
+
+    #[test]
+    fn parse_validate_shortcut() {
+        assert_eq!(ReplCommand::parse("v").unwrap(), ReplCommand::Validate);
+    }
+
+    #[test]
+    fn parse_submit_shortcut() {
+        assert_eq!(ReplCommand::parse("s").unwrap(), ReplCommand::Submit);
+    }
+
+    #[test]
+    fn parse_help_shortcut() {
+        assert_eq!(ReplCommand::parse("h").unwrap(), ReplCommand::Help);
+    }
+
+    #[test]
+    fn parse_quit_shortcut() {
+        assert_eq!(ReplCommand::parse("q").unwrap(), ReplCommand::Quit);
     }
 
     // Integration tests for state persistence


### PR DESCRIPTION
## Summary
Adds single-letter shortcuts for all REPL commands with improved help display using bracket notation, enhancing UX for power users.

Closes #62 (AGX-057)

## Features Implemented

### ✅ Command Shortcuts
All REPL commands now support intuitive single-letter shortcuts:

| Shortcut | Full Command | Description |
|----------|--------------|-------------|
| `a` | `add` | Add task to plan |
| `p` | `preview` | Preview current plan |
| `e` | `edit` | Edit specific task |
| `r` | `remove` | Remove task |
| `c` | `clear` | Clear plan |
| `v` | `validate` | Run Delta validation |
| `s` | `submit` | Submit plan to AGQ |
| `h` | `help` | Show help |
| `q` | `quit` | Exit REPL |

### ✅ Improved Help Display
- **Version number**: Shows "AGX Interactive REPL v0.1.0"
- **Bracket notation**: Commands shown as `[a]dd`, `[p]review`, etc.
- **Organized sections**: Commands, Plan Actions, Session
- **Helpful tip**: "Type the full command or just the first letter (e.g., 'a' or 'add')"

## Implementation

### Changes
- **src/repl.rs**: 
  - Updated `ReplCommand::parse()` to accept shortcuts
  - Redesigned `cmd_help()` with bracket notation and version
  - Added 9 new tests for shortcut parsing
- **README.md**: 
  - Updated examples to demonstrate shortcuts
  - Added tip about using shortcuts

### Testing
- **91 tests passing** (9 new shortcut tests added)
- Every shortcut verified to parse correctly
- Full backward compatibility maintained

## User Experience

### Before (AGX-042)
```
agx (0)> add "sort data and remove duplicates"
🤖 Generating plan steps...
✓ Added 2 task(s)

agx (2)> preview
📋 Current plan (2 tasks):
...

agx (2)> submit
```

### After (AGX-057)
```
agx (0)> a "sort data and remove duplicates"
🤖 Generating plan steps...
✓ Added 2 task(s)

agx (2)> p
📋 Current plan (2 tasks):
...

agx (2)> s
```

### New Help Output
```
AGX Interactive REPL v0.1.0

Commands:
  [a]dd <instruction>    Generate and append plan steps
  [p]review              Show current plan
  [e]dit <num>           Modify a specific step
  [r]emove <num>         Delete a specific step
  [c]lear                Reset the plan

Plan Actions:
  [v]alidate             Run Delta model validation
  [s]ubmit               Submit plan to AGQ
  save                   Manually save session

Session:
  [h]elp                 Show this help
  [q]uit                 Exit REPL

Keyboard Shortcuts:
  Ctrl-G                 Enter vi mode for editing
  Ctrl-C                 Cancel current input
  Ctrl-D                 Exit REPL

Tip: Type the full command or just the first letter (e.g., 'a' or 'add')
```

## Acceptance Criteria

✅ All REPL commands support single-letter shortcuts  
✅ Help displays shortcuts in bracket notation: `[a]dd`, `[p]review`  
✅ Both shortcut and full command work identically  
✅ Error messages suggest using `help` if command unknown  
✅ Help text shows version number  
✅ Tests verify shortcut parsing (9 new tests)  
✅ Documentation updated with shortcut reference

## Backward Compatibility

✅ All original commands still work  
✅ Existing aliases (`show`, `list`, `rm`, etc.) unchanged  
✅ No breaking changes to command parsing

## Testing Instructions

```bash
# Build and test
cargo test  # Should show 91 tests passing

# Try the REPL with shortcuts
./target/release/agx

# In REPL, test shortcuts:
agx (0)> h        # Show help
agx (0)> a "test" # Add with shortcut
agx (1)> p        # Preview with shortcut
agx (1)> c        # Clear with shortcut
agx (0)> q        # Quit with shortcut
```

## References

Similar UX patterns in other CLIs:
- `redis-cli` - Single-letter shortcuts for common commands
- `psql` - Backslash commands with shortcuts (\d, \l, etc.)
- `sqlite3` - Dot commands with shortcuts (.help, .quit, etc.)

---

**Priority**: Medium - UX enhancement  
**Effort**: Small - ~100 lines changed  
**Dependencies**: Built on top of AGX-042 (Interactive REPL)