### PR TITLE
feat: Add operational commands to REPL (AGX-058)

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,14 +49,24 @@ The REPL provides:
 
 All commands support single-letter shortcuts shown in brackets:
 
+**Plan Building:**
 - `[a]dd "<instruction>"` — Generate and append plan steps using Echo model
 - `[p]review` — Show current plan
 - `[e]dit <num>` — Modify a specific step
 - `[r]emove <num>` — Delete a specific step
 - `[c]lear` — Reset the plan
+
+**Plan Actions:**
 - `[v]alidate` — Run Delta model validation (coming in AGX-045/046)
 - `[s]ubmit` — Submit plan to AGQ (use `agx PLAN submit` for now)
 - `save` — Manually save session
+
+**Operational Commands:**
+- `[j]obs` — List all jobs from AGQ
+- `[w]orkers` — List active workers
+- `stats` / `queue` — Show queue statistics
+
+**Session:**
 - `[h]elp` — Show available commands
 - `[q]uit` — Exit REPL
 
@@ -143,6 +153,24 @@ Commands:
   [a]dd <instruction>    Generate and append plan steps
   [p]review              Show current plan
   ...
+
+agx (2)> j
+Jobs (3):
+  - job_abc123
+  - job_def456
+  - job_ghi789
+
+agx (2)> w
+Active Workers (2):
+  - worker-1 (idle)
+  - worker-2 (busy)
+
+agx (2)> stats
+Queue Statistics:
+  pending_jobs: 3
+  active_jobs: 1
+  completed_jobs: 15
+  workers: 2
 
 agx (2)> s
 📤 Submitting plan to AGQ...


### PR DESCRIPTION
Resolves #64

## Summary

Adds operational visibility commands to the AGX REPL for monitoring AGQ state without leaving the interactive session.

## New Commands

- **`[j]obs`** - List all jobs from AGQ
- **`[w]orkers`** - List active workers
- **`stats` / `queue`** - Show queue statistics

## Implementation Details

### Core Changes
- Added `ReplCommand` enum variants: `JobList`, `WorkerList`, `QueueStats`
- Updated command parser to recognize shortcuts: `j`, `w`, `stats`/`queue`
- Implemented three new command methods leveraging existing `AgqClient` methods
- Simple, readable output format with counts and bullet points

### Code Structure
```rust
// New ReplCommand variants (src/repl.rs:122-125)
JobList,
WorkerList,
QueueStats,

// Command methods (src/repl.rs:556-625)
fn cmd_job_list(&self) -> Result<(), String>
fn cmd_worker_list(&self) -> Result<(), String>
fn cmd_queue_stats(&self) -> Result<(), String>
```

## Testing

- **6 new tests** for operational command parsing
- **All 97 tests passing**
- Coverage includes full command names and shortcuts

Test coverage:
```rust
parse_jobs_command()      // "jobs" → JobList
parse_jobs_shortcut()     // "j" → JobList
parse_workers_command()   // "workers" → WorkerList
parse_workers_shortcut()  // "w" → WorkerList
parse_stats_command()     // "stats" → QueueStats
parse_queue_command()     // "queue" → QueueStats
```

## Documentation

### README.md Updates
- Reorganized command list by category:
  - Plan Building (add, preview, edit, remove, clear)
  - Plan Actions (validate, submit, save)
  - **Operational Commands** (jobs, workers, stats)
  - Session (help, quit)
- Added example showing operational commands in use
- Updated help text with new section

### Help Text
Added "Operational Commands" section to REPL help display:
```
Operational Commands:
  [j]obs                 List all jobs from AGQ
  [w]orkers              List active workers
  stats / queue          Show queue statistics
```

## Example Usage

```bash
$ agx
agx (0)> j
Jobs (3):
  - job_abc123
  - job_def456
  - job_ghi789

agx (0)> w
Active Workers (2):
  - worker-1 (idle)
  - worker-2 (busy)

agx (0)> stats
Queue Statistics:
  pending_jobs: 3
  active_jobs: 1
  completed_jobs: 15
  workers: 2
```

## Use Cases

1. **Iterative Development** - Submit plan, check status, refine
2. **Worker Monitoring** - Verify workers are active before submitting
3. **Queue Health** - Check backlog and capacity before adding jobs

## Dependencies

Requires AGQ-022 (operational commands support in AGQ) - confirmed merged.

## Testing Checklist

- [x] Unit tests for command parsing (6 new tests)
- [x] All existing tests still pass (97/97)
- [x] Build succeeds without errors
- [x] Documentation updated (README.md, help text)
- [x] Example usage included

## Breaking Changes

None. This is purely additive functionality.

## Future Work

- Add `--json` flag for machine-readable output (like CLI commands)
- Add filtering/sorting options for job lists
- Real-time updates with watch mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)