### PR TITLE
feat: Add PLAN/ACTION commands to REPL interface (AGX-073)

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,14 @@ All commands support single-letter shortcuts shown in brackets:
 - `[s]ubmit` — Submit plan to AGQ (use `agx PLAN submit` for now)
 - `save` — Manually save session
 
+**Plan Operations:**
+- `plan list` — List all stored plans from AGQ
+- `plan get <id>` — View details of a specific plan
+
+**Action Operations:**
+- `action <plan-id>` — Execute plan (no input)
+- `action <plan-id> <json>` — Execute plan with input data
+
 **Operational Commands:**
 - `[j]obs` — List all jobs from AGQ
 - `[w]orkers` — List active workers
@@ -266,10 +274,25 @@ Queue Statistics:
   completed_jobs: 15
   workers: 2
 
-agx (2)> s
-📤 Submitting plan to AGQ...
-⚠️  Submit via REPL not yet fully integrated
-   Use 'agx PLAN submit' for now
+agx (2)> plan list
+Plans (2):
+  plan_abc123def456 (5 tasks) - Process log files
+  plan_xyz789ghi012 (3 tasks) - Backup database
+
+agx (2)> plan get plan_abc123def456
+Plan: plan_abc123def456
+Tasks:
+  1. grep ERROR app.log
+  2. wc -l
+  3. sort
+  4. uniq
+  5. tee results.txt
+
+agx (2)> action plan_abc123def456 {"path": "/var/log"}
+✅ Action submitted successfully
+Job ID: job_607bbd71ef8940d5ab53d174fcd6911a
+Plan: plan_abc123def456
+Input: {"path": "/var/log"}
 
 agx (2)> q
 Saving session...


### PR DESCRIPTION
## Summary

Implements PLAN and ACTION commands directly in REPL, making it the primary interface as intended. Users no longer need to exit REPL to use these critical features.

## Changes

### New Commands
- **`plan list`** - List all stored plans from AGQ
- **`plan get <id>`** - View details of a specific plan
- **`action <plan-id>`** - Execute plan (no input)
- **`action <plan-id> <json>`** - Execute plan with input data

### Implementation
All three commands reuse existing CLI logic:
- `cmd_plan_list()` → `AgqClient.list_plans()`
- `cmd_plan_get()` → `AgqClient.get_plan()`
- `cmd_action_submit()` → Full ACTION submit workflow (same as CLI)

### Security
- Plan-id validation (alphanumeric + underscore/dash only, max 128 chars)
- Input JSON validation
- RESP injection prevention
- Reuses security measures from CLI implementation (src/lib.rs:739-810)

### Tests
**8 new tests (123 total passing):**
- `parse_plan_list_command()` - Parse "plan list"
- `parse_plan_get_command()` - Parse "plan get <id>"
- `plan_get_requires_plan_id()` - Error handling
- `plan_requires_subcommand()` - Error handling
- `plan_rejects_unknown_subcommand()` - Error handling
- `parse_action_command_no_input()` - Parse "action <id>"
- `parse_action_command_with_input()` - Parse with JSON
- `action_requires_plan_id()` - Error handling

All existing tests still pass ✅

### Example Session
```bash
agx> plan list
Plans (2):
  plan_abc123def456 (5 tasks) - Process log files
  plan_xyz789ghi012 (3 tasks) - Backup database

agx> plan get plan_abc123def456
Plan: plan_abc123def456
Tasks:
  1. grep ERROR app.log
  2. wc -l
  3. sort
  4. uniq
  5. tee results.txt

agx> action plan_abc123def456 {"path": "/var/log"}
✅ Action submitted successfully
Job ID: job_607bbd71ef8940d5ab53d174fcd6911a
Plan: plan_abc123def456
Input: {"path": "/var/log"}
```

## Documentation
- ✅ Updated REPL Commands section in README
- ✅ Updated help text in REPL
- ✅ Added comprehensive example showing new workflow

## Acceptance Criteria

- [x] `plan list` works in REPL
- [x] `plan get <id>` works in REPL
- [x] `action <plan-id>` works in REPL (empty input)
- [x] `action <plan-id> <json>` works in REPL (with input)
- [x] Error messages for invalid input
- [x] Help text updated with new commands
- [x] All existing REPL commands still work
- [x] Unit tests for new command parsing
- [x] Documentation updated

## REPL-First Design

This completes the REPL-first architecture where all user-facing functionality is accessible from the interactive session. Users no longer need to drop to CLI mode for plan operations or action execution.

Closes #73

🤖 Generated with [Claude Code](https://claude.com/claude-code)